### PR TITLE
Fix missing zod locale module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.4.0",
-        "axios": "^1.6.0"
+        "axios": "^1.6.0",
+        "zod": "^3.23.8"
       },
       "bin": {
         "agentops-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentops-mcp",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "MCP index access to the AgentOps Public API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,7 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.4.0",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Add `zod` as a direct dependency and update the package version to fix `ERR_MODULE_NOT_FOUND` when running via `npx`.

The `ERR_MODULE_NOT_FOUND` for `zod/v3/locales/en.js` occurred because `zod` was a transitive dependency of `@modelcontextprotocol/sdk`. When `agentops-mcp` was run via `npx`, the temporary installation did not correctly resolve `zod`'s internal module paths, specifically its `locales` directory. Adding `zod` as a direct dependency ensures it is properly included and resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc3a3135-1529-4395-9a77-43a87122cf55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc3a3135-1529-4395-9a77-43a87122cf55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>